### PR TITLE
Fix a bug in methods swizzling implementation.

### DIFF
--- a/UIKitWorkarounds/Utils/NNSwizzlingUtils.m
+++ b/UIKitWorkarounds/Utils/NNSwizzlingUtils.m
@@ -3,7 +3,6 @@
 //  UIKitWorkarounds
 //
 //  Created by Nick Tymchenko on 28/01/16.
-//  Based on http://nshipster.com/method-swizzling/
 //
 
 #import "NNSwizzlingUtils.h"
@@ -12,25 +11,31 @@
 @implementation NNSwizzlingUtils
 
 + (void)swizzle:(Class)aClass instanceMethod:(SEL)originalSelector withMethod:(SEL)swizzledSelector {
-    Method originalMethod = class_getInstanceMethod(aClass, originalSelector);
-    Method swizzledMethod = class_getInstanceMethod(aClass, swizzledSelector);
+    NSParameterAssert(aClass);
+    NSParameterAssert(!sel_isEqual(originalSelector, swizzledSelector));
     
-    BOOL didAddMethod = class_addMethod(aClass,
-                                        originalSelector,
-                                        method_getImplementation(swizzledMethod),
-                                        method_getTypeEncoding(swizzledMethod));
+    SEL const sel1 = originalSelector;
+    SEL const sel2 = swizzledSelector;
+    Method const method1 = class_getInstanceMethod(aClass, sel1);
+    Method const method2 = class_getInstanceMethod(aClass, sel2);
+    IMP const imp1 = method_getImplementation(method1);
+    IMP const imp2 = method_getImplementation(method2);
+    char const *const typeEncoding1 = method_getTypeEncoding(method1);
+    char const *const typeEncoding2 = method_getTypeEncoding(method2);
     
-    if (didAddMethod) {
-        class_replaceMethod(aClass,
-                            swizzledSelector,
-                            method_getImplementation(originalMethod),
-                            method_getTypeEncoding(originalMethod));
-    } else {
-        method_exchangeImplementations(originalMethod, swizzledMethod);
-    }
+    NSAssert(strcmp(typeEncoding1, typeEncoding2) == 0, @"Failed to swizzle methods with different signatures.");
+    
+    class_addMethod(aClass, sel1, imp2, typeEncoding2) || method_setImplementation(method1, imp2);
+    class_addMethod(aClass, sel2, imp1, typeEncoding1) || method_setImplementation(method2, imp1);
+    
+    NSAssert(class_getMethodImplementation(aClass, sel1) == imp2, nil);
+    NSAssert(class_getMethodImplementation(aClass, sel2) == imp1, nil);
 }
 
 + (void)swizzle:(Class)aClass classMethod:(SEL)originalSelector withMethod:(SEL)swizzledSelector {
+    NSParameterAssert(aClass);
+    NSParameterAssert(!sel_isEqual(originalSelector, swizzledSelector));
+    
     [self swizzle:object_getClass(aClass) instanceMethod:originalSelector withMethod:swizzledSelector];
 }
 


### PR DESCRIPTION
Take into account the case when the `originalSelector` is implemented in the `aClass` and the `swizzledSelector` is implemented in the base class.

The current implementation was replacing the implementation of the `swizzledSelector` in the base class while it should have been adding the implementation to the `aClass`.